### PR TITLE
next parent image

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,10 @@
-FROM node:14-alpine as build
+FROM node:18-alpine
 
 WORKDIR /app
 COPY package*.json /app/
 RUN npm install
 COPY . /app
+COPY --from=kernai/refinery-parent-images:v1.11.0-next /app/node_modules /app/node_modules
 RUN npm run build
 
 ENTRYPOINT /usr/local/bin/npm run start

--- a/dev.Dockerfile
+++ b/dev.Dockerfile
@@ -1,4 +1,4 @@
-FROM node:14-alpine
+FROM node:18-alpine
 
 WORKDIR /app
 
@@ -7,5 +7,7 @@ VOLUME ["/app"]
 COPY package*.json /app/
 
 RUN npm install --also=dev
+
+COPY --from=kernai/refinery-parent-images:v1.11.0-next /app/node_modules /app/node_modules
 
 ENTRYPOINT /usr/local/bin/npm run dev

--- a/package.json
+++ b/package.json
@@ -13,19 +13,12 @@
     "@ory/integrations": "^1.1.0",
     "@ory/kratos-client": "^0.11.1",
     "@ory/themes": "^0.0.101",
-    "@types/node": "18.15.12",
-    "@types/react": "18.0.37",
-    "@types/react-dom": "18.0.11",
     "cors": "^2.8.5",
     "eslint": "8.38.0",
     "eslint-config-next": "13.3.0",
     "express": "^4.18.2",
-    "next": "13.3.0",
-    "react": "18.2.0",
-    "react-dom": "18.2.0",
     "react-toastify": "^9.1.2",
-    "styled-components": "^5.3.9",
-    "typescript": "5.0.4"
+    "styled-components": "^5.3.9"
   },
   "devDependencies": {
     "@types/cors": "^2.8.13",

--- a/start
+++ b/start
@@ -9,6 +9,7 @@ docker run --rm -d \
 --name refinery-entry \
 -p 7080:3000 \
 --mount type=bind,source="$(pwd)"/,target=/app \
+-v /app/node_modules \
 --network dev-setup_default \
 refinery-entry-dev
 


### PR DESCRIPTION
introduces parent image for next based on node 18
https://github.com/code-kern-ai/refinery-next-parent-image

see:

- https://github.com/code-kern-ai/admin-dashboard/pull/13
- https://github.com/code-kern-ai/gates-ui/pull/18
- https://github.com/code-kern-ai/refinery-entry/pull/6
- https://github.com/code-kern-ai/chat-ui/pull/18
- https://github.com/code-kern-ai/workflow-ui/pull/24